### PR TITLE
fix: drop ZDC Ecal WSciFi fibers for speed

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -1,6 +1,16 @@
 name: linux-eic-shell
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   xmllint:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -37,7 +37,7 @@ jobs:
           cmake --build build -- install
     - uses: actions/upload-artifact@v3
       with:
-        name: install
+        name: build-eic-shell
         path: install/
         if-no-files-found: error
 
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -114,7 +114,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main
@@ -134,7 +134,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v3
       with:
-        name: install
+        name: build-eic-shell
         path: install/
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: eic/run-cvmfs-osg-eic-shell@main

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -132,6 +132,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         setup: install/setup.sh
         run: |
+          sed -i '/<fiber/,+4d' ${BEAMLINE_PATH}/ip6/far_forward/ZDC_Ecal_WSciFi.xml
           bin/generate_prim_file -o prim -D -t detector_view -c ip6.xml
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -133,7 +133,7 @@ jobs:
         setup: install/setup.sh
         run: |
           sed -i '/<fiber/,+4d' ${BEAMLINE_PATH}/ip6/far_forward/ZDC_Ecal_WSciFi.xml
-          bin/generate_prim_file -o prim -D -t detector_view -c ip6.xml
+          bin/generate_prim_file -o prim -D -t detector_view -c ${BEAMLINE_PATH}/${BEAMLINE}.xml
     - uses: actions/upload-artifact@v3
       with:
         name: detector_view.prim

--- a/.github/workflows/linux-lcg.yml
+++ b/.github/workflows/linux-lcg.yml
@@ -1,6 +1,16 @@
 name: linux-lcg
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-lcg-ubuntu-2004:


### PR DESCRIPTION
The fibers are both slow and result in large prim files. This drops all fibers from the ZDC visualization.