### PR TITLE
ci: add 'since' input; scheduled run Monday 16:30Z

### DIFF
--- a/.github/workflows/generate-weekly-meeting-slides.yml
+++ b/.github/workflows/generate-weekly-meeting-slides.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: eic/generate-meeting-slides@v2
       with:
-        since: "1 week ago"
+        since: ${{ inputs.since || '1 week ago' }}
         config: |
           repos:  
             - name: ${{ github.repository }}

--- a/.github/workflows/generate-weekly-meeting-slides.yml
+++ b/.github/workflows/generate-weekly-meeting-slides.yml
@@ -1,7 +1,14 @@
+name: generate-weekly-meeting-slides
 on:
   schedule:
-    - cron:  '30 11 * * 1' # 11:30 UTC = 07:30 EDT on Monday
+    - cron:  '30 16 * * 1' # 16:30 UTC = 12:30 EDT on Monday
   workflow_dispatch:
+    inputs:
+      since:
+        description: 'Since when to generate slides'
+        required: false
+        type: string
+        default: '1 week ago'
 
 jobs:
   generate-weekly-meeting-slides:


### PR DESCRIPTION
This adds a `since` input to the meeting slides run to allow for deviations from the default '1 week ago' durations. Also changes the scheduled run time to Monday 16:30 UTC, 12:30 EDT.