### PR TITLE
fix: write single hit collection for Roman Pots and Off-Momentum Trackers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ list(TRANSFORM DD4hep_required_libraries PREPEND DD4hep::)
 
 # Dependencies
 find_package(DD4hep REQUIRED COMPONENTS ${DD4hep_required_components})
+if(${DD4hep_VERSION} VERSION_LESS 1.21)
+  message(WARNING "DD4hep before 1.21 does not write collections correctly \n"
+                  "More info at https://github.com/AIDASoft/DD4hep/pull/922")
+endif()
 find_package(ActsDD4hep)
 if(ActsDD4hep_FOUND)
   add_compile_definitions(USE_ACTSDD4HEP)

--- a/ip6/far_forward/offM_tracker.xml
+++ b/ip6/far_forward/offM_tracker.xml
@@ -25,7 +25,7 @@
       id="ForwardOffMTracker_station_1_ID"
       name="ForwardOffMTracker_station_1"
       type="ip6_OffMomentumTracker"
-      readout="ForwardOffMTrackerHits1"
+      readout="ForwardOffMTrackerHits"
       vis="FFTrackerVis"
       reflect="false">
       <position x="-780.0*mm" y="0" z="22500*mm"/>
@@ -41,7 +41,7 @@
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
       </module>
       <layer id="1" module="Module1">
-        <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="1.0*cm" 
+        <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="1.0*cm"
           zstart="0.0/2.0" />
       </layer>
     </detector>
@@ -50,7 +50,7 @@
       id="ForwardOffMTracker_station_2_ID"
       name="ForwardOffMTracker_station_2"
       type="ip6_OffMomentumTracker"
-      readout="ForwardOffMTrackerHits2"
+      readout="ForwardOffMTrackerHits"
       vis="AnlRed"
       reflect="false">
       <position x="-780.0*mm" y="0" z="22520*mm"/>
@@ -65,17 +65,17 @@
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
       </module>
       <layer id="1" module="Module1">
-         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm" 
+         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
            zstart="0.0/2.0" />
       </layer>
-      
+
     </detector>
 
     <detector
       id="ForwardOffMTracker_station_3_ID"
       name="ForwardOffMTracker_station_3"
       type="ip6_OffMomentumTracker"
-      readout="ForwardOffMTrackerHits3"
+      readout="ForwardOffMTrackerHits"
       vis="FFTrackerVis"
       reflect="false">
       <position x="-870.0*mm" y="0" z="24500*mm"/>
@@ -90,17 +90,17 @@
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
       </module>
       <layer id="1" module="Module1">
-         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm" 
+         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
           zstart="0.0/2.0" />
       </layer>
-      
+
     </detector>
 
     <detector
       id="ForwardOffMTracker_station_4_ID"
       name="ForwardOffMTracker_station_4"
       type="ip6_OffMomentumTracker"
-      readout="ForwardOffMTrackerHits4"
+      readout="ForwardOffMTrackerHits"
       vis="FFTrackerVis"
       reflect="false">
       <position x="-870.0*mm" y="0" z="24520*mm"/>
@@ -115,31 +115,19 @@
         <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
       </module>
       <layer id="1" module="Module1">
-         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm" 
+         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
           zstart="0.0/2.0" />
       </layer>
-      
+
     </detector>
 
 
   </detectors>
 
   <readouts>
-    <readout name="ForwardOffMTrackerHits1">
+    <readout name="ForwardOffMTrackerHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
-      <id>system:8,layer:5,module:5,slice:4,x:32:-16,y:-16</id>  
-    </readout>
-    <readout name="ForwardOffMTrackerHits2">
-      <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
-      <id>system:8,layer:5,module:5,slice:4,x:32:-16,y:-16</id>  
-    </readout>
-    <readout name="ForwardOffMTrackerHits3">
-      <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
-      <id>system:8,layer:5,module:5,slice:4,x:32:-16,y:-16</id>  
-    </readout>
-    <readout name="ForwardOffMTrackerHits4">
-      <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
-      <id>system:8,layer:5,module:5,slice:4,x:32:-16,y:-16</id>  
+      <id>system:8,layer:5,module:5,slice:4,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/ip6/far_forward/roman_pots_eRD24_design.xml
+++ b/ip6/far_forward/roman_pots_eRD24_design.xml
@@ -8,11 +8,11 @@
       Date of first commit: June 15th, 2021
       ---------------------------------
     </comment>
-    
+
     <!-- Global "station" location, rotation, position information -->
-    
+
     <constant name="ForwardRomanPotStation1_zpos" value="26.0*m"/>
-    <constant name="ForwardRomanPotStation1_xpos" value="-0.8333878326*m"/> 
+    <constant name="ForwardRomanPotStation1_xpos" value="-0.8333878326*m"/>
 	  <constant name="ForwardRomanPotStation2_zpos" value="28.0*m"/>
     <constant name="ForwardRomanPotStation2_xpos" value="-0.924342804*m"/>
 
@@ -24,34 +24,34 @@
 
 	<!-- Module/layer information -->
 	<!-- Each module is simply a 3.2cm wide by 3.2cm tall square -->
-    
+
 	<!-- Module insertion positions -->
 
-    	
+
 
 	<constant name="ForwardRomanPotStation1_insertion_outer" value="3.2*cm"/>
-    <constant name="ForwardRomanPotStation2_insertion_outer" value="3.2*cm"/> 
+    <constant name="ForwardRomanPotStation2_insertion_outer" value="3.2*cm"/>
 
 	<!-- HIGH ACCEPTANCE VALUES -->
 
 	<!--
-	
+
 	<constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.0*cm"/>
-	
+
 	<constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.8*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.8*cm"/>
 
 	-->
 
 	<!-- HIGH DIVERGENCE VALUES -->
-	
+
 	<constant name="ForwardRomanPotStation1_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_intermediate" value="3.2*cm + 0.6*cm"/>
 
     <constant name="ForwardRomanPotStation1_insertion_central" value="3.2*cm + 0.7*cm"/>
     <constant name="ForwardRomanPotStation2_insertion_central" value="3.2*cm + 0.7*cm"/>
-	
+
 
 	<!-- Each module is a sandwich of 1mm aluminum, 0.3mm air, 0.3mm silicon, 0.3mm inactive silicon, 0.3mm copper, and 1mm aluminum -->
 	<!-- Vacuum is between each module -->
@@ -81,7 +81,7 @@
   <detectors>
     <detector id="ForwardRomanPot_Station_1_ID"
       name="ForwardRomanPot_Station_1"
-      readout="ForwardRomanPotHits1" 
+      readout="ForwardRomanPotHits"
       type="ip6_ForwardRomanPot"
       insideTrackingVolume="true"
       reflect="false" vis="FFTrackerVis">
@@ -103,7 +103,7 @@
       <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="ForwardRomanPotStation1_insertion_outer"/>
       </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight"> 
+      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="0" y="ForwardRomanPotStation1_insertion_central"/>
       </array>
 	  <array nx="1" ny="2" module="Module1" width="ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
@@ -114,10 +114,10 @@
       </array>
     </module_assembly>
     <module_assembly name="Station1Bottom">
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight"> 
+      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="(4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0" y="-ForwardRomanPotStation1_insertion_outer"/>
       </array>
-      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight"> 
+      <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
         <position x="-((4*ForwardRomanPot_ModuleWidth)/2.0 + (2*ForwardRomanPot_ModuleWidth)/2.0)" y="-ForwardRomanPotStation1_insertion_outer"/>
       </array>
       <array nx="2" ny="2" module="Module1" width="2*ForwardRomanPot_ModuleWidth" height="2*ForwardRomanPot_ModuleHeight">
@@ -155,7 +155,7 @@
   <detector
       id="ForwardRomanPot_Station_2_ID"
       name="ForwardRomanPot_Station_2"
-      readout="ForwardRomanPotHits2"
+      readout="ForwardRomanPotHits"
       type="ip6_ForwardRomanPot"
       insideTrackingVolume="true"
       reflect="false"
@@ -233,15 +233,10 @@
 
 
   <readouts>
-    <readout name="ForwardRomanPotHits1">
-      <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
-      <id>system:8,assembly:3,layer:4,module:4,sensor:4,x:32:-16,y:-16</id>
-    </readout>
-    <readout name="ForwardRomanPotHits2">
+    <readout name="ForwardRomanPotHits">
       <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
       <id>system:8,assembly:3,layer:4,module:4,sensor:4,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 
 </lccdd>
-


### PR DESCRIPTION
### Briefly, what does this PR introduce?
About half a year ago (or longer), when switching fully from dd4pod to edm4hep, we had to put all hits in a dedicated collection instead of reusing the collections across subdetectors. This reverts the behavior as DD4hep versions 1.21 and later have fixed this issues.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
  - Benchmarks need updating:
    - [x] https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/merge_requests/130
    - [x] https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks/-/merge_requests/269
    - [x] https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/merge_requests/179
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators:
  - [x] Post on mattermost about this
  - [x] Let @ajentsch know about this

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Yes. This now requires DD4hep 1.21 or newer for correct behavior (more recent than LCG 101).

### Does this PR change default behavior?
Yes. By default the hits collections for roman pots and off-momentum trackers will not be numbered anymore.