### PR TITLE
fix: run CI also on pushes to master, not just main

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/linux-lcg.yml
+++ b/.github/workflows/linux-lcg.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
At all times, we want to make sure there is a latest run of the CI on the main/master branch. When copying over the CI workflows from epic, we did not change the default branch name to the one used here.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: no CI is run on master branch pushes in eic/ip6)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.