### PR TITLE
fix: ZDC_Crystal_Hits -> ZDCEcalHits, ZDC_PbScinti_Hits -> ZDCHcalHits

### DIFF
--- a/ip6/far_forward/ZDC_Crystal.xml
+++ b/ip6/far_forward/ZDC_Crystal.xml
@@ -44,7 +44,7 @@
   </detectors>
 
   <readouts>
-    <readout name="ZDC_Crystal_Hits">
+    <readout name="ZDCEcalHits">
       <segmentation type="NoSegmentation"/>
       <id>system:8,module:2,crystal:12</id>
     </readout>

--- a/ip6/far_forward/ZDC_PbScinti.xml
+++ b/ip6/far_forward/ZDC_PbScinti.xml
@@ -34,7 +34,7 @@
   </detectors>
 
   <readouts>
-    <readout name="ZDC_PbSci_Hits">
+    <readout name="ZDCHcalHits">
       <segmentation type="CartesianGridXY" grid_size_x="10.*cm" grid_size_y="10.*cm"/>
       <id>system:8,scinti:6,x:24:-12,y:-12</id>
     </readout>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
#26 introduced new readout names, which translate into new hit collections that are used for reconstruction. This is now causing reconstructions to fail in many benchmarks (including full simulation production reconstruction) and causing analysis of these hit collections to fail due to the rename. So, we're just going to back out the name change.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: failing detector benchmarks, reconstruction benchmarks, physics benchmarks)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [X] Changes have been communicated to collaborators @ajentsch @shimasnd 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes. Back to ZDCEcalHits and ZDCHcalHits.