### PR TITLE
Added beampipe envelope size at end of hadron endcap

### DIFF
--- a/ip6/central_beampipe.xml
+++ b/ip6/central_beampipe.xml
@@ -59,6 +59,7 @@
           <zplane z="BeampipeDownstreamStraightLength + 0.5 * BeampipeOD * tan(abs(CrossingAngle))" OD="BeampipeOD"/>
           <zplane z="1750.00 * mm" OD=" 92.06 * mm"/>
           <zplane z="4455.80 * mm" OD="257.92 * mm"/>
+          <zplane z="5000.00 * mm" OD="340.60 * mm"/>
         </outgoing_hadron>
         <additional_subtraction thickness="4.0*mm"
                                 crossing_angle="CrossingAngle">


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The expanding beampipe should extend to the hadron endcap to ensure no overlaps are introduced by future geometry development.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #33 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None. Could create additional overlaps that weren't there previously, but so far have not seen any.

### Does this PR change default behavior?
Yes, the beampipe is slightly longer and larger in the outgoing hadron direction.