### PR TITLE
Make build module function in B0 ecal static

### DIFF
--- a/src/B0ECal_geo.cpp
+++ b/src/B0ECal_geo.cpp
@@ -19,7 +19,7 @@ using std::vector;
 using std::map;
 using namespace dd4hep;
 
-tuple<Volume, Position> build_module(Detector& desc, xml_coll_t& plm, SensitiveDetector& sens);
+static tuple<Volume, Position> build_module(Detector& desc, xml_coll_t& plm, SensitiveDetector& sens);
 
 static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens)
 {
@@ -69,7 +69,7 @@ static Ref_t createDetector(Detector& desc, xml_h e, SensitiveDetector sens)
 }
 
 // helper function to build module with or w/o wrapper
-tuple<Volume, Position> build_module(Detector& desc, xml::Collection_t& plm, SensitiveDetector& sens)
+static tuple<Volume, Position> build_module(Detector& desc, xml::Collection_t& plm, SensitiveDetector& sens)
 {
   auto   mod = plm.child(_Unicode(module));
   auto   sx  = mod.attr<double>(_Unicode(sizex));


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Make build module function in B0 ecal static so that it doesn't get picked up by other elements

### What kind of change does this PR introduce?
- [X] Bug fix (issue #40)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No