### PR TITLE
44 update arches and brycecanyon to point to correct magnet files

### DIFF
--- a/ip6/far_forward_brycecanyon.xml
+++ b/ip6/far_forward_brycecanyon.xml
@@ -4,7 +4,7 @@
   <include ref="far_forward/ion_beamline.xml" />
   <include ref="far_forward/beampipe_hadron_B0.xml" />
   <include ref="far_forward/B0_tracker.xml"/>
-  <include ref="far_forward/B0_preshower.xml"/>
+  <include ref="far_forward/B0_ECal.xml"/>
   <include ref="far_forward/offM_tracker.xml"/>
   <include ref="far_forward/ZDC.xml"/>
   <include ref="far_forward/roman_pots_eRD24_design.xml"/>

--- a/ip6_brycecanyon.xml
+++ b/ip6_brycecanyon.xml
@@ -14,7 +14,7 @@
     <comment>
       Change this to 275/100/41 to change the field setup
     </comment>
-    <include ref="ip6/far_forward/fields_275.xml"/>
+    <include ref="ip6/far_forward/fields_41.xml"/>
 
     <constant name="tracker_region_zmax" value="10*m"/>
     <constant name="tracker_region_rmax" value="1*m"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Makes Arches and BryceCanyon point to the correct magnet settings and B0 calorimetry components.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes - the BryceCanyon config now use 41 GeV hadron beam settings, and the B0 ECal.
