### PR TITLE
fix: ZDC_rotateY_angle = ionCrossingAngle

### DIFF
--- a/ip6/far_forward/ZDC.xml
+++ b/ip6/far_forward/ZDC.xml
@@ -12,7 +12,7 @@
     <constant name="ZDC_x_pos"         value="ZDC_z_pos * ionCrossingAngle"/>
     <constant name="ZDC_y_pos"         value="0.0 * cm"/>
     <constant name="ZDC_rotateX_angle" value="0.0 * rad"/>
-    <constant name="ZDC_rotateY_angle" value="0.0125 * rad"/> <!-- was negative prior to big flip -->
+    <constant name="ZDC_rotateY_angle" value="ionCrossingAngle"/> <!-- was negative prior to big flip -->
     <constant name="ZDC_rotateZ_angle" value="0.0 * rad"/>
     <constant name="ZDC_width"         value="60.0 * cm"/>
     <constant name="ZDC_length"        value="200.0 * cm"/>


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Updated ZDC_rotateY_angle to be consistent with coord. system with e- beamline along global z-axis.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.
