### PR TITLE
hotfix: do not use hard-coded ID numbers without definitions

### DIFF
--- a/ip6.xml
+++ b/ip6.xml
@@ -70,20 +70,17 @@
     <documentation>
       #### (190-199) Far Backward Beamline Detectors
 
-      - Low-Q2 Tagger 1 Tracker      ID: 195
-      - Low-Q2 Tagger 1 Calorimeter  ID: 196
-      - Low-Q2 Tagger 2 Tracker      ID: 198
-      - Low-Q2 Tagger 2 Calorimeter  ID: 199
+      - Low-Q2 Tagger 1       ID: 195
+      - Low-Q2 Tagger 2       ID: 196
+      - Low-Q2 Tagger Vacuum  ID: 199
 
       TODO: A lot of the repeated ID's below should be pushed into a single detector
     </documentation>
     <constant name="LumiCollimator_ID"       value="190"/>
     <constant name="LumiDipole_ID"           value="191"/>
-    <constant name="Tagger_ID"               value="195"/>
-    <!--constant name="TaggerTracker_1_ID"      value="195"/-->
-    <!--constant name="TaggerCalorimeter_1_ID"  value="196"/-->
-    <!--constant name="TaggerTracker_2_ID"      value="198"/-->
-    <!--constant name="TaggerCalorimeter_2_ID"  value="199"/-->
+    <constant name="Tagger1_ID"              value="195"/>
+    <constant name="Tagger2_ID"              value="196"/>
+    <constant name="TaggerVacuum_ID"         value="199"/>
 
     <documentation>
       #### (200-219) Far Backward Beamline Magnets

--- a/ip6/far_backward/taggers.xml
+++ b/ip6/far_backward/taggers.xml
@@ -8,8 +8,8 @@
   </define>
 
   <detectors>
-    
-    <detector id="1" type="BackwardsTracker" name="TagTrack1"
+
+    <detector id="Tagger1_ID" type="BackwardsTracker" name="TagTrack1"
       width="Tagger1_Width/2"
       height="Tagger1_Height/2"
       length="Tagger1_Length"
@@ -24,7 +24,7 @@
     </detector>
 
 
-    <detector id="2" type="BackwardsTracker" name="TagTrack2"
+    <detector id="Tagger2_ID" type="BackwardsTracker" name="TagTrack2"
       width="Tagger2_Width/2"
       height="Tagger2_Height/2"
       length="Tagger2_Length"

--- a/ip6/far_backward/vacuum.xml
+++ b/ip6/far_backward/vacuum.xml
@@ -2,15 +2,15 @@
 <lccdd>
 
   <define>
-   
+
   </define>
 
   <detectors>
 
     <comment> Main vacuum volume </comment>
-    <detector id="Tagger_ID" name="BackwardsTaggerVacuum" type="BackwardsVacuum" wall="2*mm" lumi="true" vis="BackwardsBox">
+    <detector id="TaggerVacuum_ID" name="BackwardsTaggerVacuum" type="BackwardsVacuum" wall="2*mm" lumi="true" vis="BackwardsBox">
       <focus      x="Dipole_Focus_X"    y="Dipole_Focus_Y"    z="Dipole_Focus_Z" />
-      <bounding  
+      <bounding
         xmin="Vacuum_BB_MinX"
         xmax="Vacuum_BB_MaxX"
         ymin="Vacuum_BB_MinY"
@@ -46,7 +46,7 @@
       </module>
 
     </detector>
-     
+
   </detectors>
 
 </lccdd>

--- a/ip6_arches.xml
+++ b/ip6_arches.xml
@@ -69,20 +69,17 @@
     <documentation>
       #### (190-199) Far Backward Beamline Detectors
 
-      - Low-Q2 Tagger 1 Tracker      ID: 195
-      - Low-Q2 Tagger 1 Calorimeter  ID: 196
-      - Low-Q2 Tagger 2 Tracker      ID: 198
-      - Low-Q2 Tagger 2 Calorimeter  ID: 199
+      - Low-Q2 Tagger 1       ID: 195
+      - Low-Q2 Tagger 2       ID: 196
+      - Low-Q2 Tagger Vacuum  ID: 199
 
       TODO: A lot of the repeated ID's below should be pushed into a single detector
     </documentation>
     <constant name="LumiCollimator_ID"       value="190"/>
     <constant name="LumiDipole_ID"           value="191"/>
-    <constant name="Tagger_ID"               value="195"/>
-    <!--constant name="TaggerTracker_1_ID"      value="195"/-->
-    <!--constant name="TaggerCalorimeter_1_ID"  value="196"/-->
-    <!--constant name="TaggerTracker_2_ID"      value="198"/-->
-    <!--constant name="TaggerCalorimeter_2_ID"  value="199"/-->
+    <constant name="Tagger1_ID"              value="195"/>
+    <constant name="Tagger2_ID"              value="196"/>
+    <constant name="TaggerVacuum_ID"         value="199"/>
 
     <documentation>
       #### (200-219) Far Backward Beamline Magnets

--- a/ip6_brycecanyon.xml
+++ b/ip6_brycecanyon.xml
@@ -69,20 +69,17 @@
     <documentation>
       #### (190-199) Far Backward Beamline Detectors
 
-      - Low-Q2 Tagger 1 Tracker      ID: 195
-      - Low-Q2 Tagger 1 Calorimeter  ID: 196
-      - Low-Q2 Tagger 2 Tracker      ID: 198
-      - Low-Q2 Tagger 2 Calorimeter  ID: 199
+      - Low-Q2 Tagger 1       ID: 195
+      - Low-Q2 Tagger 2       ID: 196
+      - Low-Q2 Tagger Vacuum  ID: 199
 
       TODO: A lot of the repeated ID's below should be pushed into a single detector
     </documentation>
     <constant name="LumiCollimator_ID"       value="190"/>
     <constant name="LumiDipole_ID"           value="191"/>
-    <constant name="Tagger_ID"               value="195"/>
-    <!--constant name="TaggerTracker_1_ID"      value="195"/-->
-    <!--constant name="TaggerCalorimeter_1_ID"  value="196"/-->
-    <!--constant name="TaggerTracker_2_ID"      value="198"/-->
-    <!--constant name="TaggerCalorimeter_2_ID"  value="199"/-->
+    <constant name="Tagger1_ID"              value="195"/>
+    <constant name="Tagger2_ID"              value="196"/>
+    <constant name="TaggerVacuum_ID"         value="199"/>
 
     <documentation>
       #### (200-219) Far Backward Beamline Magnets


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Rather than defining `id="1"` in the IP6 geometry, this must be defined with an appropriate `*_ID` variable in BOTH the `ip6.xml` entrypoint and the epic `compact/defintions.xml`, at least until we merge these repositories.

### What kind of change does this PR introduce?
- [X] Bug fix (issue: currently broken inclusion of ip6 in epic)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.